### PR TITLE
Fix broken star history charts in READMEs

### DIFF
--- a/MPDocBench/tools/idp_tools/Dolphin/README.md
+++ b/MPDocBench/tools/idp_tools/Dolphin/README.md
@@ -223,4 +223,4 @@ If you find this code useful for your research, please use the following BibTeX 
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=bytedance/Dolphin&type=Date)](https://www.star-history.com/#bytedance/Dolphin&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=bytedance/Dolphin&type=Date)](https://star-history.dera.page/#bytedance/Dolphin&Date)

--- a/MPDocBench/tools/idp_tools/Dolphin/README_CN.md
+++ b/MPDocBench/tools/idp_tools/Dolphin/README_CN.md
@@ -220,4 +220,4 @@ python demo_layout.py --model_path ./hf_model --save_dir ./results \
 
 ## 星标历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=bytedance/Dolphin&type=Date)](https://www.star-history.com/#bytedance/Dolphin&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=bytedance/Dolphin&type=Date)](https://star-history.dera.page/#bytedance/Dolphin&Date)

--- a/QwenLong-L1/README.md
+++ b/QwenLong-L1/README.md
@@ -349,4 +349,4 @@ If you find this work is relevant with your research or applications, please fee
 
 ## ⭐️ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Tongyi-Zhiwen/QwenLong-L1&type=Timeline)](https://star-history.com/#Tongyi-Zhiwen/QwenLong-L1&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Tongyi-Zhiwen/QwenLong-L1&type=Timeline)](https://star-history.dera.page/#Tongyi-Zhiwen/QwenLong-L1&Timeline)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This repository currently includes the following projects:
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Tongyi-Zhiwen/Qwen-Doc&type=Timeline)](https://star-history.com/#Tongyi-Zhiwen/Qwen-Doc&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Tongyi-Zhiwen/Qwen-Doc&type=Timeline)](https://star-history.dera.page/#Tongyi-Zhiwen/Qwen-Doc&Timeline)
 
 ## 📝 Citation
 


### PR DESCRIPTION
The star history charts across the README files are broken and no longer render. This update switches them to a working chart source so the charts display again. Also fixes the chart link in the Dolphin README files.